### PR TITLE
Resolve deprecation messages with PHP 8.1

### DIFF
--- a/API/KalturaClientBase.php
+++ b/API/KalturaClientBase.php
@@ -48,21 +48,21 @@ class MultiRequestSubResult implements ArrayAccess
         return new MultiRequestSubResult($this->value . ':' . $name);
 	}
 
-	public function offsetExists($offset)
+	public function offsetExists(mixed $offset): bool
 	{
 		return true;
 	}
 
-	public function offsetGet($offset)
+	public function offsetGet(mixed $offset): mixed
 	{
         return new MultiRequestSubResult($this->value . ':' . $offset);
 	}
 
-	public function offsetSet($offset, $value)
+	public function offsetSet(mixed $offset, mixed $value): void
 	{
 	}
 
-	public function offsetUnset($offset)
+	public function offsetUnset(mixed $offset): void
 	{
 	}
 }


### PR DESCRIPTION
This resolves #1 

```
root@e7d21010cac7:/var/www/moodle# vendor/bin/phpunit --testsuite='local_kaltura_testsuite'
Moodle 4.2.3+ (Build: 20231020), 03bd101ede0a1ce62fdf8f63b9942933929ee6ea
Php: 8.1.2.1.2.14, pgsql: 14.0 (Debian 14.0-1.pgdg110+1), OS: Linux 6.2.0-35-generic x86_64
PHPUnit 9.5.28 by Sebastian Bergmann and contributors.

................................................................. 65 / 80 ( 81%)
...............                                                   80 / 80 (100%)

Time: 00:02.941, Memory: 82.50 MB

OK (80 tests, 182 assertions)
```